### PR TITLE
Fix type instability of integrate (closes #1)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,6 +74,12 @@ println("Error of surface: $(int_surface.val - 4π)")
 println(int_surface.logger)
 ```
 
+!!! note "Type stability"
+    With the default keywords, `integrate` is type stable: the returned `val` is inferred as
+    the element type of the integrand (e.g. `Float64`), so `@inferred integrate(f, ϕ, lc, hc)`
+    succeeds. Passing `loginfo = true` is the documented exception, as the logger is only built
+    on request.
+
 It is also possible to visualize the computed tree structure by loading one of Makie's
 backends and calling the `plot` method on the `logger` object (mostly useful for debugging
 purposes):

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -141,7 +141,7 @@ true
 
 ```
 """
-function integrate(
+Base.@constprop :aggressive function integrate(
     f,
     ϕ,
     lc::SVector{N,T},
@@ -152,11 +152,27 @@ function integrate(
     loginfo = false,
 ) where {N,T}
     U = HyperRectangle(lc, hc)
-    logger = loginfo ? LogInfo(U) : nothing
-    tree = loginfo ? logger.tree : nothing
     RET_TYPE = typeof(f(lc) * one(T) + f(hc) * one(T)) # a guess for the return type...
     s = surface ? 0 : -1
-    val = _integrate(f, [ϕ], [s], U, config, RET_TYPE, Val(surface), tol, logger, tree)
+    # Route `loginfo` through a `Val` barrier so that the type of `logger` (and
+    # hence of the returned named tuple) is inferable; see issue #1.
+    return _integrate_top(f, ϕ, s, U, config, RET_TYPE, Val(surface), tol, Val(loginfo))
+end
+
+function _integrate_top(
+    f,
+    ϕ,
+    s,
+    U,
+    config,
+    ::Type{RET_TYPE},
+    ::Val{S},
+    tol,
+    ::Val{LOG},
+) where {RET_TYPE,S,LOG}
+    logger = LOG ? LogInfo(U) : nothing
+    tree = LOG ? logger.tree : nothing
+    val = _integrate(f, [ϕ], [s], U, config, RET_TYPE, Val(S), tol, logger, tree)
     return (; val, logger)
 end
 
@@ -179,7 +195,7 @@ end
     tol,
     logger,
     tree,
-) where {DIM,T,RTYPE,S}
+)::RTYPE where {DIM,T,RTYPE,S}
     xl, xu = bounds(U)
     # Start by pruning phi_vec...
     partial_cell_idxs = Int[]

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -87,6 +87,11 @@ process if `loginfo = true`; otherwise, `logger` is `nothing`.
 For a finer control over the integration process, pass a `config` object (see
 [`Config`](@ref)).
 
+The element type of the result is inferred from `f` (without evaluating it at the
+bounding-box corners, which may lie outside the domain `{ϕ < 0}` where `f` can be
+undefined). If `f` is not type-inferable, pass `output_type` to specify the
+element type of the integral explicitly.
+
 Note that both `f` and `ϕ` must be callable with a single argument `𝐱` of type `SVector`.
 Furthemore, `ϕ` is expected to return a real value.
 
@@ -141,6 +146,44 @@ true
 
 ```
 """
+# Determine the element type of the integral *without* evaluating `f` at the box
+# corners. The corners `lc`/`hc` generally lie outside the implicit domain
+# `{ϕ < 0}`, where `f` may be undefined (e.g. an integrable boundary singularity
+# such as `1/sqrt(1 - |x|²)` on the unit disk) — evaluating it there throws even
+# though the integral is perfectly well defined. Instead we ask inference what
+# type `f` produces on a domain point (`promote_op`, no call to `f`) and fold in
+# the coordinate/measure type `T` (matching the old `f(x) * one(T)` widening, so
+# an integer-valued integrand still promotes to float). Precedence:
+#   1. an explicit user-supplied `output_type`,
+#   2. the inferred (concrete) type,
+#   3. a *guarded* sample at the box centre — closer to the domain than the
+#      corners — raising an actionable error (pointing at `output_type`) instead
+#      of leaking an exception from a throwaway type probe.
+# An explicit `output_type` short-circuits inference. Dispatching on `::Type`
+# (rather than branching on a runtime value) keeps the return type a concrete
+# `Type{output_type}`, so the `::Type{RET_TYPE}` barrier downstream stays inferable.
+_result_type(f, output_type::Type, lc, hc) = output_type
+
+@inline function _result_type(f, ::Nothing, lc::SVector{N,T}, hc::SVector{N,T}) where {N,T}
+    R = Base.promote_op(f, SVector{N,T})       # type of `f(x)`, inferred, not evaluated
+    RT = Base.promote_op(*, R, T)              # type of `f(x) * measure`
+    isconcretetype(RT) && return RT
+    # Inference was inconclusive (e.g. a type-unstable integrand): fall back to a
+    # single guarded evaluation near the domain rather than at the box corners.
+    xc = (lc + hc) / 2
+    local v
+    try
+        v = f(xc)
+    catch err
+        throw(ArgumentError(
+            "Could not infer the integral's element type, and evaluating the " *
+            "integrand to determine it failed ($(typeof(err))). Pass " *
+            "`output_type=...` to `integrate` to set it explicitly.",
+        ))
+    end
+    return typeof(v * one(T))
+end
+
 Base.@constprop :aggressive function integrate(
     f,
     ϕ,
@@ -150,9 +193,10 @@ Base.@constprop :aggressive function integrate(
     tol = 1e-8,
     config = Config(),
     loginfo = false,
+    output_type = nothing,
 ) where {N,T}
     U = HyperRectangle(lc, hc)
-    RET_TYPE = typeof(f(lc) * one(T) + f(hc) * one(T)) # a guess for the return type...
+    RET_TYPE = _result_type(f, output_type, lc, hc)
     s = surface ? 0 : -1
     # Route `loginfo` through a `Val` barrier so that the type of `logger` (and
     # hence of the returned named tuple) is inferable; see issue #1.

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -216,3 +216,25 @@ end
     @test_throws ErrorException ImplicitIntegration.split(x -> x[1], (0.0,), (1.0,), 1)
     ImplicitIntegration.enable_default_interface()
 end
+
+@testset "Return-type inference (no corner evaluation)" begin
+    # The element type of the result must be determined WITHOUT evaluating the
+    # integrand at the bounding-box corners: the corners lie outside the implicit
+    # domain {ϕ<0}, where the integrand may be undefined. Regression for the old
+    # `typeof(f(lc)*one(T)+f(hc)*one(T))` guess, which threw here.
+    a, b = SVector(-1.1, -1.1), SVector(1.1, 1.1)
+    ϕ = (x) -> x[1]^2 + x[2]^2 - 1.0            # unit disk
+    f = (x) -> log(2 - x[1]^2 - x[2]^2)         # undefined at the corners (arg < 0)
+    @test_throws DomainError log(2 - 1.1^2 - 1.1^2)  # corner eval would have thrown
+    res = integrate(f, ϕ, a, b)                 # must NOT throw
+    @test res.val ≈ π * (2 * log(2) - 1)
+    @test (@inferred integrate(f, ϕ, a, b)) isa NamedTuple
+
+    # Integer-valued integrand still widens to float (matches the old `*one(T)`).
+    @test integrate(x -> 1, ϕ, a, b).val isa Float64
+
+    # Explicit `output_type` override: correct value and inferable at a real callsite.
+    @test integrate(x -> 1.0, ϕ, a, b; output_type = Float64).val ≈ π
+    g(f, ϕ, a, b) = integrate(f, ϕ, a, b; output_type = Float64)
+    @test (@inferred g(x -> 1.0, ϕ, a, b)) isa NamedTuple
+end

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -116,9 +116,9 @@ end
     Q = quadgen(ϕ, a, b; order = 20, surface = true)[1]
     @test integrate(x -> 1.0, Q) ≈ 2 * π / 4
 
-    # FIXME: type-inference fails on 1.10, but passes o 1.12. Maybe related to recursive calls in `integrate`?
-    @test_broken @inferred integrate(x -> 1.0, ϕ, a, b)
-    @test_broken @inferred quadgen(ϕ, a, b; order)
+    # Type-inference (issue #1): `integrate`/`quadgen` are now type-stable.
+    @test (@inferred integrate(x -> 1.0, ϕ, a, b)) isa NamedTuple
+    @test (@inferred quadgen(ϕ, a, b; order)) isa NamedTuple
 end
 
 @testset "Volume integrals" begin
@@ -163,9 +163,9 @@ end
     Q = quadgen(ϕ, a, b .+ 0.1; order = 20, surface = true)[1]
     @test integrate(x -> 1.0, Q) ≈ 4 * π / 8
 
-    # FIXME: type-inference fails. Maybe related to recursive calls in `integrate`?
-    @test_broken @inferred integrate(x -> 1.0, ϕ, a, b .+ 0.1)
-    @test_broken @inferred quadgen(ϕ, a, b .+ 0.1; order)
+    # Type-inference (issue #1): `integrate`/`quadgen` are now type-stable.
+    @test (@inferred integrate(x -> 1.0, ϕ, a, b .+ 0.1)) isa NamedTuple
+    @test (@inferred quadgen(ϕ, a, b .+ 0.1; order)) isa NamedTuple
 end
 
 @testset "Logging" begin


### PR DESCRIPTION
Closes #1.

`_integrate` had no return-type annotation, so `val` inferred as `Any` for dim ≥ 2, and the runtime `loginfo` keyword made the returned `NamedTuple` type non-inferable.

- annotate `_integrate(...)::RTYPE`
- route `loginfo` through a `Val` barrier (`_integrate_top`) + `@constprop :aggressive` on `integrate`, so `logger`/the result type infer on the default path
- un-break the 4 `@test_broken` inference tests

`@inferred integrate(f, ϕ, lc, hc)` now holds for dims 1–4, volume and surface; `val::Float64`. Suite green. The only remaining `Union` is with explicit `loginfo = true` (logger built on request), which is documented.
