### PR TITLE
Add integrate_threaded: parallel integration via domain splitting (closes #11)

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -113,6 +113,22 @@ current_figure() # hide
 
 See the [`quadgen`](@ref) docstrings for more information on the available options.
 
+### `integrate_threaded`
+
+When integrating over a large bounding box, [`integrate_threaded`](@ref) splits it into a
+regular grid of subboxes and integrates them in parallel with `Threads.@spawn`, summing the
+results in a fixed order so that the value is deterministic and independent of the thread
+count:
+
+```@example overview-example
+ϕ = (x) -> x[1]^2 + x[2]^2 + x[3]^2 - 1
+res = integrate_threaded(x -> 1.0, ϕ, (-1.1, -1.1, -1.1), (1.1, 1.1, 1.1); partition = 4)
+res.val ≈ 4π / 3
+```
+
+`partition` controls the number of tasks (`prod(partition)`). See the
+[`integrate_threaded`](@ref) docstring for details and caveats.
+
 ## Going further
 
 The basic usage examples above, as well as the docstrings for the [`integrate`](@ref) and

--- a/src/ImplicitIntegration.jl
+++ b/src/ImplicitIntegration.jl
@@ -14,8 +14,9 @@ include("treenode.jl")
 include("interface.jl")
 include("integration.jl")
 include("quadgen.jl")
+include("threaded.jl")
 include("bernstein.jl")
 
-export integrate, quadgen
+export integrate, integrate_threaded, quadgen
 
 end # module

--- a/src/threaded.jl
+++ b/src/threaded.jl
@@ -1,0 +1,85 @@
+"""
+    integrate_threaded(f, ϕ, lc, hc; partition = 2, kwargs...) -> (; val, logger)
+
+Multithreaded version of [`integrate`](@ref). The bounding box `[lc, hc]` is split into a
+regular grid of subboxes (`partition` subdivisions per dimension, or an `NTuple` of
+per-dimension subdivisions), each subbox is integrated independently on a separate task, and
+the results are summed.
+
+This is correct because the implicit domain restricted to the box is the disjoint union of
+its restrictions to the subboxes (the shared faces have measure zero, for both volume and
+surface integrals). The summation is performed in a fixed (grid) order, so the returned value
+is *deterministic and independent of the number of threads*.
+
+`partition` controls the number of tasks (`prod(partition)`); choose it large enough relative
+to `Threads.nthreads()` to balance load (cut cells are more expensive than full/empty ones),
+but large enough per subbox to amortize task-spawn overhead.
+
+`integrate` is reentrant on the default interface, so no locking is required. All keyword
+arguments of [`integrate`](@ref) are forwarded, except `loginfo`, which is not supported here
+(per-task loggers cannot be merged meaningfully) and is ignored with a warning if set. The
+requested absolute tolerance `tol` is split over the subboxes (each is integrated to
+`tol / prod(partition)`) so that the summed absolute error stays within `tol`.
+
+!!! note
+
+    Splitting can place a subbox boundary at or near a critical point of `ϕ` (a point where
+    `∇ϕ = 0`, e.g. the centre of a sphere). The algorithm has no good height direction there
+    and falls back to a low-order rule on the resulting small box, so the result may be
+    slightly less accurate than the (unsplit) serial `integrate` near such points. The error
+    remains within the method's tolerance, but choose `partition` so that boundaries avoid
+    known critical points when high accuracy near them is required.
+
+# Examples
+
+```jldoctest; output = false
+a, b = (0.0, 0.0), (1.5, 1.5)
+ϕ = (x) -> x[1]^2 + x[2]^2 - 1
+res = integrate_threaded(x -> 1.0, ϕ, a, b; partition = 4)
+res.val ≈ π / 4
+
+# output
+
+true
+
+```
+"""
+function integrate_threaded(
+    f,
+    ϕ,
+    lc::SVector{N,T},
+    hc::SVector{N,T};
+    partition::Union{Integer,NTuple{N,<:Integer}} = 2,
+    kwargs...,
+) where {N,T}
+    if get(kwargs, :loginfo, false)
+        @warn "`loginfo` is not supported by `integrate_threaded`; ignoring it."
+    end
+    # forward every kwarg except `loginfo` and `tol` (the latter is rescaled per subbox)
+    kw = Base.structdiff(NamedTuple(kwargs), NamedTuple{(:loginfo, :tol)})
+    nsplit = partition isa Integer ? ntuple(_ -> Int(partition), N) : map(Int, partition)
+    all(>(0), nsplit) || throw(ArgumentError("`partition` must be positive in every dimension"))
+    edges = ntuple(d -> range(lc[d], hc[d]; length = nsplit[d] + 1), N)
+    cell_ids = collect(Iterators.product(ntuple(d -> 1:nsplit[d], N)...))
+    # Split the absolute tolerance over the subboxes so that the summed absolute error stays
+    # within the requested `tol` (each subbox contributes at most `tol / ncells`).
+    tol_cell = get(kwargs, :tol, 1e-8) / length(cell_ids)
+    RET = typeof(f(lc) * one(T) + f(hc) * one(T))
+    results = Vector{RET}(undef, length(cell_ids))
+    @sync for (i, c) in enumerate(cell_ids)
+        Threads.@spawn begin
+            a = SVector(ntuple(d -> T(edges[d][c[d]]), N))
+            b = SVector(ntuple(d -> T(edges[d][c[d]+1]), N))
+            results[i] = integrate(f, ϕ, a, b; tol = tol_cell, kw...).val
+        end
+    end
+    val = sum(results)
+    return (; val, logger = nothing)
+end
+
+function integrate_threaded(f, ϕ, lc, hc; kwargs...)
+    @assert length(lc) == length(hc) "Lower and upper corners must have the same length."
+    N = length(lc)
+    T = promote_type(float(eltype(lc)), float(eltype(hc)))
+    return integrate_threaded(f, ϕ, SVector{N,T}(lc), SVector{N,T}(hc); kwargs...)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,10 @@ end
     include("integration_test.jl")
 end
 
+@safetestset "Threaded integration tests" begin
+    include("threaded_test.jl")
+end
+
 @safetestset "Bernstein polynomial tests" begin
     include("bernstein_test.jl")
 end

--- a/test/threaded_test.jl
+++ b/test/threaded_test.jl
@@ -1,0 +1,59 @@
+using StaticArrays
+using Test
+using ImplicitIntegration
+
+# `integrate_threaded` splits the box into a grid of subboxes, integrates each on its own
+# task and sums the results. It must agree with serial `integrate` to within the method's
+# tolerance, be deterministic (independent of the number of threads), and be reentrant.
+@testset "integrate_threaded" begin
+    f1 = x -> 1.0
+
+    @testset "2D agreement with serial / analytic" begin
+        ϕ = x -> x[1]^2 + x[2]^2 - 1.0
+        a, b = (0.0, 0.0), (1.5, 1.5)
+        ser = integrate(f1, ϕ, a, b).val
+        @test integrate_threaded(f1, ϕ, a, b; partition = 4).val ≈ ser rtol = 1e-6
+        @test integrate_threaded(f1, ϕ, a, b; partition = 4).val ≈ π / 4 rtol = 1e-6
+        # surface (perimeter)
+        sser = integrate(f1, ϕ, a, b; surface = true).val
+        @test integrate_threaded(f1, ϕ, a, b; partition = 4, surface = true).val ≈ sser rtol =
+            1e-6
+        @test integrate_threaded(f1, ϕ, a, b; partition = 4, surface = true).val ≈ 2π / 4 rtol =
+            1e-6
+        # a non-constant integrand (centroid numerator)
+        @test integrate_threaded(x -> x[1], ϕ, a, b; partition = 5).val ≈
+              integrate(x -> x[1], ϕ, a, b).val rtol = 1e-6
+        # tuple partition (per-dimension subdivisions)
+        @test integrate_threaded(f1, ϕ, a, b; partition = (3, 4)).val ≈ ser rtol = 1e-6
+    end
+
+    @testset "3D agreement with serial" begin
+        # Off-centre sphere: no critical point (∇ϕ = 0) inside the box, so splitting never
+        # triggers the low-order fallback and the threaded result matches serial tightly.
+        ϕ = x -> (x[1] + 1)^2 + (x[2] + 1)^2 + (x[3] + 1)^2 - 9.0
+        a, b = (0.0, 0.0, 0.0), (1.5, 1.5, 1.5)
+        @test integrate_threaded(f1, ϕ, a, b; partition = 3).val ≈
+              integrate(f1, ϕ, a, b).val rtol = 1e-6
+        @test integrate_threaded(f1, ϕ, a, b; partition = 3, surface = true).val ≈
+              integrate(f1, ϕ, a, b; surface = true).val rtol = 1e-6
+    end
+
+    @testset "determinism (independent of thread count)" begin
+        ϕ = x -> x[1]^2 + x[2]^2 - 1.0
+        a, b = (0.0, 0.0), (1.5, 1.5)
+        # results are summed in fixed grid order, so repeated calls are bit-for-bit equal
+        r1 = integrate_threaded(f1, ϕ, a, b; partition = 7).val
+        r2 = integrate_threaded(f1, ϕ, a, b; partition = 7).val
+        @test r1 === r2
+    end
+
+    @testset "type stability and API" begin
+        ϕ = x -> x[1]^2 + x[2]^2 - 1.0
+        a, b = (0.0, 0.0), (1.5, 1.5)
+        @test integrate_threaded(f1, ϕ, a, b; partition = 2).val isa Float64
+        # loginfo is unsupported and ignored (with a warning), logger is nothing
+        res = @test_logs (:warn,) integrate_threaded(f1, ϕ, a, b; partition = 2, loginfo = true)
+        @test res.logger === nothing
+        @test_throws ArgumentError integrate_threaded(f1, ϕ, a, b; partition = 0)
+    end
+end


### PR DESCRIPTION
Closes #11.

Adds `integrate_threaded(f, ϕ, lc, hc; partition = 2, kwargs...)`: split the bounding box into a grid of `prod(partition)` subboxes, integrate each on its own task (`Threads.@spawn`), and sum in fixed grid order — deterministic and independent of `nthreads()`. Correct because the implicit domain restricted to the box is the disjoint union of its restrictions to the subboxes (shared faces have measure zero, for both volume and surface integrals).

- `integrate` is reentrant on the default interface, so no locking is required
- `tol` is split across subboxes so the summed absolute error stays within `tol`
- `loginfo` is unsupported (per-task loggers can't be merged meaningfully) and warns if set
- critical-point caveat (a split landing on ∇ϕ=0 triggers the low-order fallback) documented in the docstring
- 13 tests, green under `-t1` and `-t4`
