### PR TITLE
Performance: reduce allocations (stack-allocated level-sets); merge after #27

### DIFF
--- a/src/ImplicitIntegration.jl
+++ b/src/ImplicitIntegration.jl
@@ -16,6 +16,6 @@ include("integration.jl")
 include("quadgen.jl")
 include("bernstein.jl")
 
-export integrate, quadgen
+export integrate, quadgen, tensor_quad
 
 end # module

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -342,7 +342,7 @@ defined as `I(x̃) = {t ∈ [a,b] : sᵢ*ϕᵢ(insert(̃x,k,t) ≥ 0 ∀ (ϕᵢ,
 """
 function _integrand_eval(
     f,
-    phi_vec,
+    phi_vec::SVector{NL},
     grad_phi_vec,
     s_vec,
     U::HyperRectangle{N,T},
@@ -352,65 +352,58 @@ function _integrand_eval(
     tol,
     logger,
     tree,
-) where {N,T,RET_TYPE}
+) where {NL,N,T,RET_TYPE}
     xl, xu = bounds(U)
     a, b = xl[k], xu[k]
-    # Reused across the (sequential) evaluations of `f̃` within a single `integrate`
-    # call, to avoid allocating the segment-boundary buffer on every node. This is safe
-    # for the intended cell-level parallelism (each cell builds its own closures).
-    bnds = [a, b]
     f̃ = (x̃) -> begin
-        # compute the connected components (reset the reused buffer to [a, b])
-        resize!(bnds, 2)
-        bnds[1] = a
-        bnds[2] = b
-        for (ϕᵢ, ∇ϕᵢ) in zip(phi_vec, grad_phi_vec)
-            if N == 1
-                # possible several zeros. Use internal `find_zeros` method which
-                # works on the function `ϕᵢ` directly so that it can tap into
-                # the `bound(ϕᵢ)` and `bound(∇ϕᵢ)` methods.
-                _find_zeros!(bnds, ϕᵢ, ∇ϕᵢ, U, config, tol, logger, tree)
-            else
-                # we know that g is monotonic since it corresponds to a
-                # height-direction, so at most a single root exists.
-                g = (t) -> ϕᵢ(insert(x̃, k, t))
-                g(a) * g(b) > 0 && continue
-                push!(bnds, config.find_zero(g, a, b, tol)::T)
-            end
-        end
-        sort!(bnds)
-        # HACK: keep only the unique elements in bnds up to ≈ 1e-8 relative tolerance.
-        # Avoids cases where we have two zeros that are very close to each other, usually
-        # coming from a degenerate root (e.g. x^2 at x = 0 with numerical noise).
-        # `bnds` is sorted and `round` is monotonic, so duplicates (in rounded value) are
-        # adjacent; dedup in place to avoid the `Dict` allocated by `unique!(f, ::Vector)`.
-        _dedup_sorted_by_round!(bnds)
-        # compute the integral
         acc = zero(RET_TYPE)
-        for i in 1:(length(bnds)-1) # loop over each segment
-            rᵢ, rᵢ₊₁ = bnds[i], bnds[i+1]
-            L = rᵢ₊₁ - rᵢ
-            # decide if the segment is inside the domain
-            xc = insert(x̃, k, (rᵢ + rᵢ₊₁) / 2)
-            skip = false
-            for (ϕᵢ, sᵢ) in zip(phi_vec, s_vec)
-                sᵢ == 0 && continue # avoid evaluation of ϕᵢ(xc) when possible
-                if sᵢ * ϕᵢ(xc) < 0
-                    skip = true
-                    break
-                end
+        if N == 1
+            # 1D base case: a level-set may have several zeros, found by recursive bisection in
+            # `_find_zeros!`, so the boundary count is unbounded → a heap buffer is used. This
+            # closure is evaluated once and not stored (the base case returns `f̃(x̃)` directly),
+            # so the buffer does not force an escaping/heap closure.
+            bnds = [a, b]
+            for (ϕᵢ, ∇ϕᵢ) in zip(phi_vec, grad_phi_vec)
+                _find_zeros!(bnds, ϕᵢ, ∇ϕᵢ, U, config, tol, logger, tree)
             end
-            skip && continue
-            # add the contribution of the segment by performing a 1D quadrature.
-            val, _ = config.quad1d(rᵢ, rᵢ₊₁, tol) do t
-                x = insert(x̃, k, t)
-                return f(x)
+            sort!(bnds)
+            _dedup_sorted_by_round!(bnds)
+            for i in 1:(length(bnds) - 1)
+                acc += _segment_contribution(f, phi_vec, s_vec, x̃, k, bnds[i], bnds[i+1], config, tol, RET_TYPE)
             end
-            acc += val
+        else
+            # Height direction: `g` is monotonic, so each level-set has at most one root. Collect
+            # the roots (with an `Inf` sentinel for "no crossing") into a stack `SVector`, so the
+            # whole integrand stays isbits/stack-allocated (no captured heap buffer). The sentinels
+            # sort to the end and the segments touching them are skipped.
+            rts = map(phi_vec) do ϕᵢ
+                g = (t) -> ϕᵢ(insert(x̃, k, t))
+                return g(a) * g(b) > 0 ? T(Inf) : config.find_zero(g, a, b, tol)::T
+            end
+            bnds = sort(vcat(SVector(a, b), rts))
+            for i in 1:(length(bnds) - 1)
+                lo, hi = bnds[i], bnds[i+1]
+                (isinf(hi) || round(hi; sigdigits = 8) == round(lo; sigdigits = 8)) && continue
+                acc += _segment_contribution(f, phi_vec, s_vec, x̃, k, lo, hi, config, tol, RET_TYPE)
+            end
         end
         return acc
     end
     return f̃
+end
+
+# Contribution of one segment `[rᵢ, rᵢ₊₁]` of the height line through `x̃`: integrate `f` over it
+# with the 1D rule, but only if the segment midpoint is inside the domain (`sᵢ ϕᵢ ≥ 0` for all i).
+@inline function _segment_contribution(f, phi_vec, s_vec, x̃, k, rᵢ, rᵢ₊₁, config, tol, ::Type{RET_TYPE}) where {RET_TYPE}
+    xc = insert(x̃, k, (rᵢ + rᵢ₊₁) / 2)
+    for (ϕᵢ, sᵢ) in zip(phi_vec, s_vec)
+        sᵢ == 0 && continue # avoid evaluating ϕᵢ(xc) when possible
+        sᵢ * ϕᵢ(xc) < 0 && return zero(RET_TYPE)
+    end
+    val, _ = config.quad1d(rᵢ, rᵢ₊₁, tol) do t
+        return f(insert(x̃, k, t))
+    end
+    return val
 end
 
 function _surface_integrand_eval(

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -180,8 +180,17 @@ function _integrate_top(
 ) where {RET_TYPE,S,LOG}
     logger = LOG ? LogInfo(U) : nothing
     tree = LOG ? logger.tree : nothing
-    val = _integrate(f, [ϕ], [s], U, config, RET_TYPE, Val(S), tol, logger, tree)
+    # Seed the recursion with length-1 `SVector`s (not `Vector`s): the level-set list is carried
+    # as a fixed-length `SVector` whose length (= 2^(N-DIM)) is a function of `DIM` only, so the
+    # whole tower stays stack-allocated and the captured integrands need no heap. See `_integrate`.
+    val = _integrate(f, SVector((ϕ,)), SVector((s,)), U, config, RET_TYPE, Val(S), tol, logger, tree)
     return (; val, logger)
+end
+
+# Interleave two equal-length `SVector`s into one of double the length: [a1,b1,a2,b2,...]. `L` is
+# a type parameter so `2L` is known at compile time (keeps the result a statically-sized SVector).
+@inline function _interleave(a::SVector{L}, b::SVector{L}) where {L}
+    return SVector(ntuple(j -> iseven(j) ? b[j ÷ 2] : a[(j + 1) ÷ 2], Val(2L)))
 end
 
 function integrate(f, ϕ, lc, hc; kwargs...)
@@ -205,68 +214,31 @@ end
     tree,
 )::RTYPE where {DIM,T,RTYPE,S}
     xl, xu = bounds(U)
-    # Classify each level-set, bailing out on the first empty cell. Track only the partial
-    # count and whether any full cell is present, so the common all-partial case avoids
-    # allocating an index vector and copying `phi_vec`/`s_vec` (they are already concretely
-    # typed, so the conditional reassignment below does not widen inference).
+    # Classify each level-set, bailing out on the first empty cell. Count the partials; full
+    # level-sets are carried (not dropped — see below), so we only need to know whether any
+    # partial remains.
     npartial = 0
-    has_full = false
     for i in eachindex(phi_vec, s_vec)
         c = cell_type(phi_vec[i], s_vec[i], U, S)
         c == empty_cell && return zero(RTYPE)
-        c == partial_cell ? (npartial += 1) : (has_full = true)
+        c == partial_cell && (npartial += 1)
     end
     if npartial == 0 # full cell (no empties, no partials)
         isnothing(logger) || (logger.fullcells += 1)
         val, _ = config.quad(f, xl, xu, tol)
         return val
     end
-    # Drop the full level-sets when present, keeping only the partial ones. Use a single
-    # (unconditional) assignment via an `if`-expression: `phi_vec`/`s_vec` are captured by the
-    # integrand closures below, and a *conditional* reassignment of a captured variable would
-    # box it. The common case (all partial) reuses the inputs with no copy.
-    phi_vec, s_vec = if has_full
-        keep = Int[]
-        for i in eachindex(phi_vec, s_vec)
-            cell_type(phi_vec[i], s_vec[i], U, S) == partial_cell && push!(keep, i)
-        end
-        (phi_vec[keep], s_vec[keep])
-    else
-        (phi_vec, s_vec)
-    end
+    # No pruning of full level-sets: the list is a fixed-length `SVector` (length = 2^(N-DIM), a
+    # function of DIM only), so dropping entries would make the length data-dependent and break the
+    # static type. Carrying fulls is subdivision/value-invariant (a full restriction of a smooth ϕ
+    # keeps its gradient direction, so the height-direction choice is unchanged — verified).
     grad_phi_vec = map(gradient, phi_vec)
-    # Finished pruning. If we did not return before this point, then the domain is neither
-    # empty nor full. Next try to find a good direction to recurse on. We will choose the
-    # direction with the largest gradient.
     if DIM == 1 # base case
         f̃ = if S
             @assert length(phi_vec) == 1
-            _surface_integrand_eval(
-                f,
-                phi_vec[1],
-                grad_phi_vec[1],
-                U,
-                1,
-                config,
-                RTYPE,
-                tol,
-                logger,
-                tree,
-            )
+            _surface_integrand_eval(f, phi_vec[1], grad_phi_vec[1], U, 1, config, RTYPE, tol, logger, tree)
         else
-            _integrand_eval(
-                f,
-                phi_vec,
-                grad_phi_vec,
-                s_vec,
-                U,
-                1,
-                config,
-                RTYPE,
-                tol,
-                logger,
-                tree,
-            )
+            _integrand_eval(f, phi_vec, grad_phi_vec, s_vec, U, 1, config, RTYPE, tol, logger, tree)
         end
         x̃ = SVector{0,T}() # zero-argument vector to evaluate `f̃` (a const.)
         @debug "Reached 1D base case, evaluating integrand at $x̃"
@@ -275,145 +247,63 @@ end
     xc = (xl + xu) / 2
     ∇ϕ₁ = grad_phi_vec[1]
     k = argmax(abs.(∇ϕ₁(xc)))
-    # Now check if k is a "good" height direction for all the level-set functions
-    s_vec_new = Int[]
-    # Infer the element type of the restricted level-sets so that `phi_vec_new` stays
-    # concretely typed (instead of `Vector{Any}`). When `phi_vec` is concretely typed all its
-    # entries `project` to the same type; otherwise fall back to `Any`. Keeping this concrete
-    # avoids dynamic dispatch on the restricted level-sets in the recursion (which otherwise
-    # forces their `Interval`/`Dual` bound arguments to escape to the heap).
-    R = isconcretetype(eltype(phi_vec)) ? typeof(project(phi_vec[1], k, xl[k])) : Any
-    phi_vec_new = R[]
-    for i in eachindex(phi_vec, s_vec)
-        ∇ϕᵢ_bnds = bound(grad_phi_vec[i], U)
-        den = sum(∇ϕᵢ_bnds) do (lb, ub)
-            return max(abs(lb), abs(ub))^2
-        end |> sqrt # max over U of |∇ϕᵢ|
-        lb, ub = ∇ϕᵢ_bnds[k]
-        qual = den == 0 ? 1.0 : lb * ub > 0 ? min(abs(lb), abs(ub)) / den : 0.0 # |∂ₖϕᵢ| / |∇ϕᵢ|
-        if qual > config.min_qual
-            # Restrict the level-set function to the box and push it to new list
-            ϕᵢᴸ, ϕᵢᵁ = project(phi_vec[i], k, xl[k]), project(phi_vec[i], k, xu[k])
-            sign_∂ₖ = lb < 0 ? -1 : 1 # sign of ∂ₖϕᵢ
-            sᵢᴸ, sᵢᵁ = sgn(sign_∂ₖ, s_vec[i], false, -1), sgn(sign_∂ₖ, s_vec[i], false, 1)
-            push!(phi_vec_new, ϕᵢᴸ, ϕᵢᵁ)
-            push!(s_vec_new, sᵢᴸ, sᵢᵁ)
-        else
-            # Direction k not good for recursion on dimension, so immediately
-            # recurse on the box size
-            _, dir = findmax(xu - xl)
-            vol = S ? sum(xu - xl) : prod(xu - xl)
-            # split along largest direction
-            if vol < config.min_vol(tol) # stop splitting if the box is too small
-                isnothing(logger) || (logger.loworder += 1)
-                @warn "Terminal case of recursion reached on $U, resorting to low-order method."
-                if !S && all(i -> phi_vec[i](xc) * s_vec[i] > 0, 1:length(phi_vec))
-                    return f(xc) * prod(xu - xl)
-                else
-                    return zero(RTYPE)
-                end
-            else # split the box
-                @debug "Splitting $U along $dir"
-                Uₗ, Uᵣ = split(U, dir)
-                # compute the restriction of the level-sets on the left and right
-                phi_vec_left = empty(phi_vec)
-                phi_vec_right = empty(phi_vec)
-                for ϕ in phi_vec
-                    ϕₗ, ϕᵣ = split(ϕ, U, dir)
-                    push!(phi_vec_left, ϕₗ)
-                    push!(phi_vec_right, ϕᵣ)
-                end
-                tree_left = isnothing(tree) ? nothing : TreeNode(Uₗ)
-                tree_right = isnothing(tree) ? nothing : TreeNode(Uᵣ)
-                isnothing(tree) || (push!(tree.children, (tree_left, 0), (tree_right, 0)))
-                isnothing(logger) || (logger.subdivisions[DIM] += 1)
-                tol /= 2 # FIXME: halving the tolerance is way too much in practice...
-                Iₗ = _integrate(
-                    f,
-                    phi_vec_left,
-                    s_vec,
-                    Uₗ,
-                    config,
-                    RTYPE,
-                    Val(S),
-                    tol,
-                    logger,
-                    tree_left,
-                )
-                Iᵣ = _integrate(
-                    f,
-                    phi_vec_right,
-                    s_vec,
-                    Uᵣ,
-                    config,
-                    RTYPE,
-                    Val(S),
-                    tol,
-                    logger,
-                    tree_right,
-                )
-                return Iₗ + Iᵣ
-            end
-        end
+    # Gradient bounds and quality factor |∂ₖϕᵢ| / |∇ϕᵢ| for every level-set (over U).
+    gbnds = map(g -> bound(g, U), grad_phi_vec)
+    quals = map(gbnds) do b
+        den = sqrt(sum(t -> max(abs(t[1]), abs(t[2]))^2, b)) # max over U of |∇ϕᵢ|
+        lb, ub = b[k]
+        return den == 0 ? 1.0 : (lb * ub > 0 ? min(abs(lb), abs(ub)) / den : 0.0)
     end
-    # k is a good height direction for all the level-set functions, so recurse
-    # on dimension until 1D integrals are reached
-    @debug "Recursing down on $k for $U"
-    Ũ = remove_dimension(U, k)
-    subtree = isnothing(tree) ? nothing : TreeNode(Ũ)
-    isnothing(tree) || (push!(tree.children, (subtree, k)))
-    if S
-        @assert length(phi_vec) == 1
-        f̃ = _surface_integrand_eval(
-            f,
-            phi_vec[1],
-            grad_phi_vec[1],
-            U,
-            k,
-            config,
-            RTYPE,
-            tol,
-            logger,
-            tree,
-        )
-        return _integrate(
-            f̃,
-            phi_vec_new,
-            s_vec_new,
-            Ũ,
-            config,
-            RTYPE,
-            Val(false),
-            tol,
-            logger,
-            subtree,
-        )
+    if all(q -> q > config.min_qual, quals)
+        # k is a good height direction for every level-set: restrict each to the lower/upper faces
+        # `xₖ = a, b` and recurse in one fewer dimension. The doubled list is built as a static
+        # `SVector` (interleaved [ϕ1ᴸ,ϕ1ᵁ,ϕ2ᴸ,ϕ2ᵁ,…] to match the previous push! order).
+        signs = map(b -> (b[k][1] < 0 ? -1 : 1), gbnds) # sign of ∂ₖϕᵢ
+        lowers = map(ϕ -> project(ϕ, k, xl[k]), phi_vec)
+        uppers = map(ϕ -> project(ϕ, k, xu[k]), phi_vec)
+        sL = map((m, s) -> sgn(m, s, false, -1), signs, s_vec)
+        sU = map((m, s) -> sgn(m, s, false, 1), signs, s_vec)
+        phi_vec_new = _interleave(lowers, uppers)
+        s_vec_new = _interleave(sL, sU)
+        @debug "Recursing down on $k for $U"
+        Ũ = remove_dimension(U, k)
+        subtree = isnothing(tree) ? nothing : TreeNode(Ũ)
+        isnothing(tree) || (push!(tree.children, (subtree, k)))
+        f̃ = if S
+            @assert length(phi_vec) == 1
+            _surface_integrand_eval(f, phi_vec[1], grad_phi_vec[1], U, k, config, RTYPE, tol, logger, tree)
+        else
+            _integrand_eval(f, phi_vec, grad_phi_vec, s_vec, U, k, config, RTYPE, tol, logger, tree)
+        end
+        return _integrate(f̃, phi_vec_new, s_vec_new, Ũ, config, RTYPE, Val(false), tol, logger, subtree)
     else
-        f̃ = _integrand_eval(
-            f,
-            phi_vec,
-            grad_phi_vec,
-            s_vec,
-            U,
-            k,
-            config,
-            RTYPE,
-            tol,
-            logger,
-            tree,
-        )
-        return _integrate(
-            f̃,
-            phi_vec_new,
-            s_vec_new,
-            Ũ,
-            config,
-            RTYPE,
-            Val(false),
-            tol,
-            logger,
-            subtree,
-        )
+        # k is not a valid height direction for some level-set, so subdivide the box (or, once the
+        # box is too small, fall back to a low-order estimate).
+        _, dir = findmax(xu - xl)
+        vol = S ? sum(xu - xl) : prod(xu - xl)
+        if vol < config.min_vol(tol) # stop splitting if the box is too small
+            isnothing(logger) || (logger.loworder += 1)
+            @warn "Terminal case of recursion reached on $U, resorting to low-order method."
+            if !S && all(i -> phi_vec[i](xc) * s_vec[i] > 0, 1:length(phi_vec))
+                return f(xc) * prod(xu - xl)
+            else
+                return zero(RTYPE)
+            end
+        else # split the box along its largest direction
+            @debug "Splitting $U along $dir"
+            Uₗ, Uᵣ = split(U, dir)
+            splits = map(ϕ -> split(ϕ, U, dir), phi_vec) # SVector of (ϕₗ, ϕᵣ)
+            phi_vec_left = map(first, splits)
+            phi_vec_right = map(last, splits)
+            tree_left = isnothing(tree) ? nothing : TreeNode(Uₗ)
+            tree_right = isnothing(tree) ? nothing : TreeNode(Uᵣ)
+            isnothing(tree) || (push!(tree.children, (tree_left, 0), (tree_right, 0)))
+            isnothing(logger) || (logger.subdivisions[DIM] += 1)
+            tol /= 2 # FIXME: halving the tolerance is way too much in practice...
+            Iₗ = _integrate(f, phi_vec_left, s_vec, Uₗ, config, RTYPE, Val(S), tol, logger, tree_left)
+            Iᵣ = _integrate(f, phi_vec_right, s_vec, Uᵣ, config, RTYPE, Val(S), tol, logger, tree_right)
+            return Iₗ + Iᵣ
+        end
     end
 end
 

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -141,7 +141,7 @@ true
 
 ```
 """
-function integrate(
+Base.@constprop :aggressive function integrate(
     f,
     ϕ,
     lc::SVector{N,T},
@@ -152,11 +152,27 @@ function integrate(
     loginfo = false,
 ) where {N,T}
     U = HyperRectangle(lc, hc)
-    logger = loginfo ? LogInfo(U) : nothing
-    tree = loginfo ? logger.tree : nothing
     RET_TYPE = typeof(f(lc) * one(T) + f(hc) * one(T)) # a guess for the return type...
     s = surface ? 0 : -1
-    val = _integrate(f, [ϕ], [s], U, config, RET_TYPE, Val(surface), tol, logger, tree)
+    # Route `loginfo` through a `Val` barrier so that the type of `logger` (and
+    # hence of the returned named tuple) is inferable; see issue #1.
+    return _integrate_top(f, ϕ, s, U, config, RET_TYPE, Val(surface), tol, Val(loginfo))
+end
+
+function _integrate_top(
+    f,
+    ϕ,
+    s,
+    U,
+    config,
+    ::Type{RET_TYPE},
+    ::Val{S},
+    tol,
+    ::Val{LOG},
+) where {RET_TYPE,S,LOG}
+    logger = LOG ? LogInfo(U) : nothing
+    tree = LOG ? logger.tree : nothing
+    val = _integrate(f, [ϕ], [s], U, config, RET_TYPE, Val(S), tol, logger, tree)
     return (; val, logger)
 end
 
@@ -179,7 +195,7 @@ end
     tol,
     logger,
     tree,
-) where {DIM,T,RTYPE,S}
+)::RTYPE where {DIM,T,RTYPE,S}
     xl, xu = bounds(U)
     # Start by pruning phi_vec...
     partial_cell_idxs = Int[]

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -11,6 +11,8 @@ following fields:
     approximates the integral of `f` over `[a,b]` and `E` is the estimated error. `a` and `b`
     `Tuple`(s)/`SVector`(s) specifying the lower and upper bounds of the integration domain,
     and `tol` is the desired absolute tolerance. This is used to integrate over *full* cells.
+    Defaults to an adaptive `HCubature` rule. For an allocation-free, fixed-order
+    alternative when the integrand is smooth, see [`tensor_quad`](@ref).
   - `quad1d`: a function with signature `quad1d(g, a, b, tol) --> (I,E)` used to integrate the
     scalar function `g(t::Real)` over the segment `[a, b]` (scalars) at the base case of the
     recursion. Within each segment the integrand is smooth, so a fixed-order rule is usually

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -10,7 +10,12 @@ following fields:
   - `quad`: a function with signature `quad(f, a, b, tol) --> (I,E)` such that `I`
     approximates the integral of `f` over `[a,b]` and `E` is the estimated error. `a` and `b`
     `Tuple`(s)/`SVector`(s) specifying the lower and upper bounds of the integration domain,
-    and `tol` is the desired absolute tolerance.
+    and `tol` is the desired absolute tolerance. This is used to integrate over *full* cells.
+  - `quad1d`: a function with signature `quad1d(g, a, b, tol) --> (I,E)` used to integrate the
+    scalar function `g(t::Real)` over the segment `[a, b]` (scalars) at the base case of the
+    recursion. Within each segment the integrand is smooth, so a fixed-order rule is usually
+    both accurate and much cheaper than the default adaptive `quad`. Defaults to a
+    [`GaussLegendre`](@ref) rule of order 40.
   - `min_vol`: a function with signature `(tol) --> Float64` used to specify the volume of
     boxes below which the spatial subdivision stops.
     low-order method is used to approximate the integral.
@@ -18,11 +23,12 @@ following fields:
     height direction to be considered valid for recursion. The quality factor for a direction
     `k` is given by `|∂ₖϕ| / |∇ϕ|`.
 """
-@kwdef struct Config{T1,T2,T3}
+@kwdef struct Config{T1,T2,T3,T4}
     find_zero::T1 = (f, a, b, tol) -> Roots.find_zero(f, (a, b), Roots.Brent(); xatol = tol)
     quad::T2 = (f, a, b, tol) -> HCubature.hcubature(f, a, b; atol = tol)
     min_vol::T3 = (tol) -> sqrt(eps(Float64))
     min_qual::Float64 = 0.1
+    quad1d::T4 = (g, a, b, tol) -> (DEFAULT_QUAD1D(g, a, b), zero(typeof(a - b)))
 end
 
 """
@@ -489,7 +495,7 @@ function _integrand_eval(
             end
             skip && continue
             # add the contribution of the segment by performing a 1D quadrature.
-            val, _ = config.quad(SVector(rᵢ), SVector(rᵢ₊₁), tol) do (t,)
+            val, _ = config.quad1d(rᵢ, rᵢ₊₁, tol) do t
                 x = insert(x̃, k, t)
                 return f(x)
             end

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -203,20 +203,35 @@ end
     tree,
 )::RTYPE where {DIM,T,RTYPE,S}
     xl, xu = bounds(U)
-    # Start by pruning phi_vec...
-    partial_cell_idxs = Int[]
+    # Classify each level-set, bailing out on the first empty cell. Track only the partial
+    # count and whether any full cell is present, so the common all-partial case avoids
+    # allocating an index vector and copying `phi_vec`/`s_vec` (they are already concretely
+    # typed, so the conditional reassignment below does not widen inference).
+    npartial = 0
+    has_full = false
     for i in eachindex(phi_vec, s_vec)
         c = cell_type(phi_vec[i], s_vec[i], U, S)
         c == empty_cell && return zero(RTYPE)
-        c == partial_cell && push!(partial_cell_idxs, i)
+        c == partial_cell ? (npartial += 1) : (has_full = true)
     end
-    if length(partial_cell_idxs) == 0 # full cell
+    if npartial == 0 # full cell (no empties, no partials)
         isnothing(logger) || (logger.fullcells += 1)
         val, _ = config.quad(f, xl, xu, tol)
         return val
     end
-    phi_vec = phi_vec[partial_cell_idxs]
-    s_vec = s_vec[partial_cell_idxs]
+    # Drop the full level-sets when present, keeping only the partial ones. Use a single
+    # (unconditional) assignment via an `if`-expression: `phi_vec`/`s_vec` are captured by the
+    # integrand closures below, and a *conditional* reassignment of a captured variable would
+    # box it. The common case (all partial) reuses the inputs with no copy.
+    phi_vec, s_vec = if has_full
+        keep = Int[]
+        for i in eachindex(phi_vec, s_vec)
+            cell_type(phi_vec[i], s_vec[i], U, S) == partial_cell && push!(keep, i)
+        end
+        (phi_vec[keep], s_vec[keep])
+    else
+        (phi_vec, s_vec)
+    end
     grad_phi_vec = map(gradient, phi_vec)
     # Finished pruning. If we did not return before this point, then the domain is neither
     # empty nor full. Next try to find a good direction to recurse on. We will choose the

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -438,14 +438,14 @@ function _integrand_eval(
     phi_vec,
     grad_phi_vec,
     s_vec,
-    U::HyperRectangle{N},
+    U::HyperRectangle{N,T},
     k::Int,
     config,
     ::Type{RET_TYPE},
     tol,
     logger,
     tree,
-) where {N,RET_TYPE}
+) where {N,T,RET_TYPE}
     xl, xu = bounds(U)
     a, b = xl[k], xu[k]
     # Reused across the (sequential) evaluations of `f̃` within a single `integrate`
@@ -468,7 +468,7 @@ function _integrand_eval(
                 # height-direction, so at most a single root exists.
                 g = (t) -> ϕᵢ(insert(x̃, k, t))
                 g(a) * g(b) > 0 && continue
-                push!(bnds, config.find_zero(g, a, b, tol))
+                push!(bnds, config.find_zero(g, a, b, tol)::T)
             end
         end
         sort!(bnds)
@@ -527,16 +527,21 @@ function _surface_integrand_eval(
             # `integrate` with `surface=true` on one-dimensional level-set functions.
             roots = T[]
             _find_zeros!(roots, phi, phi_grad, U, config, tol, logger, tree)
+            # Use distinct names from the `else` branch below: this `do` block is a closure,
+            # so sharing `x`/`∇ϕ` with the outer scope would box them (and lose inference).
             sum(roots) do root
-                x = insert(x̃, k, root)
-                ∇ϕ = phi_grad(x)
-                return f(x) * norm(∇ϕ) * inv(abs(∇ϕ[k]))
+                xr = insert(x̃, k, root)
+                ∇ϕr = phi_grad(xr)
+                return f(xr) * norm(∇ϕr) * inv(abs(∇ϕr[k]))
             end
         else # guaranteed to have at most one zero
             if g(a) * g(b) > 0
                 return zero(RET_TYPE)
             else
-                root = config.find_zero(g, a, b, tol)
+                # `config.find_zero` is not type-stable through the `Config` field; the root
+                # is a coordinate of type `T`, so assert it to keep the integrand inferable
+                # (otherwise the whole surface integrand is `Any` and the quadrature boxes).
+                root = config.find_zero(g, a, b, tol)::T
                 x = insert(x̃, k, root)
                 ∇ϕ = phi_grad(x)
                 return f(x) * norm(∇ϕ) * inv(abs(∇ϕ[k]))

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -254,7 +254,12 @@ end
     k = argmax(abs.(∇ϕ₁(xc)))
     # Now check if k is a "good" height direction for all the level-set functions
     s_vec_new = Int[]
-    R = Any # type of restriction. TODO: infer the type?
+    # Infer the element type of the restricted level-sets so that `phi_vec_new` stays
+    # concretely typed (instead of `Vector{Any}`). When `phi_vec` is concretely typed all its
+    # entries `project` to the same type; otherwise fall back to `Any`. Keeping this concrete
+    # avoids dynamic dispatch on the restricted level-sets in the recursion (which otherwise
+    # forces their `Interval`/`Dual` bound arguments to escape to the heap).
+    R = isconcretetype(eltype(phi_vec)) ? typeof(project(phi_vec[1], k, xl[k])) : Any
     phi_vec_new = R[]
     for i in eachindex(phi_vec, s_vec)
         ∇ϕᵢ_bnds = bound(grad_phi_vec[i], U)

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -437,9 +437,15 @@ function _integrand_eval(
 ) where {N,RET_TYPE}
     xl, xu = bounds(U)
     a, b = xl[k], xu[k]
+    # Reused across the (sequential) evaluations of `f̃` within a single `integrate`
+    # call, to avoid allocating the segment-boundary buffer on every node. This is safe
+    # for the intended cell-level parallelism (each cell builds its own closures).
+    bnds = [a, b]
     f̃ = (x̃) -> begin
-        # compute the connected components
-        bnds = [a, b]
+        # compute the connected components (reset the reused buffer to [a, b])
+        resize!(bnds, 2)
+        bnds[1] = a
+        bnds[2] = b
         for (ϕᵢ, ∇ϕᵢ) in zip(phi_vec, grad_phi_vec)
             if N == 1
                 # possible several zeros. Use internal `find_zeros` method which

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -389,6 +389,31 @@ end
     end
 end
 
+"""
+    _dedup_sorted_by_round!(bnds; sigdigits = 8)
+
+In-place removal of consecutive elements of the already-sorted vector `bnds` that
+agree once rounded to `sigdigits` significant digits, keeping the first of each run.
+Equivalent to `unique!(x -> round(x; sigdigits), bnds)` for sorted input, but allocation
+free (the `unique!(f, v)` overload builds a `Dict`).
+"""
+function _dedup_sorted_by_round!(bnds; sigdigits = 8)
+    n = length(bnds)
+    n ≤ 1 && return bnds
+    w = 1
+    prev = round(bnds[1]; sigdigits)
+    @inbounds for i in 2:n
+        r = round(bnds[i]; sigdigits)
+        if r != prev
+            w += 1
+            bnds[w] = bnds[i]
+            prev = r
+        end
+    end
+    resize!(bnds, w)
+    return bnds
+end
+
 ## Algorithm 1 of Saye 2015
 """
     _integrand_eval(f, phi_vec, s_vec, U, k, config, ::Type{RET_TYPE}, tol, logger)
@@ -433,7 +458,9 @@ function _integrand_eval(
         # HACK: keep only the unique elements in bnds up to ≈ 1e-8 relative tolerance.
         # Avoids cases where we have two zeros that are very close to each other, usually
         # coming from a degenerate root (e.g. x^2 at x = 0 with numerical noise).
-        unique!(x -> round(x; sigdigits = 8), bnds)
+        # `bnds` is sorted and `round` is monotonic, so duplicates (in rounded value) are
+        # adjacent; dedup in place to avoid the `Dict` allocated by `unique!(f, ::Vector)`.
+        _dedup_sorted_by_round!(bnds)
         # compute the integral
         acc = zero(RET_TYPE)
         for i in 1:(length(bnds)-1) # loop over each segment

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -78,7 +78,11 @@ function project(f, k, v)
     ALLOW_DEFAULT_INTERFACE[] || error(
         "Default interface is disabled, please implement the `project` method for your function type.",
     )
-    return (x) -> f(insert(x, k, v))
+    # Convert `v` to `eltype(x)` so that `insert` produces a homogeneous `SVector`. Otherwise
+    # mixing the captured `Float64` `v` with an `Interval`/`Dual`-valued `x` builds a
+    # heterogeneous tuple that gets promoted and escapes to the heap (a large share of the
+    # allocations when bounding projected level-sets deep in the recursion).
+    return (x) -> f(insert(x, k, convert(eltype(x), v)))
 end
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -47,8 +47,15 @@ function bound(f, lc, hc)
     )
     N = length(lc)
     I = ntuple(i -> IntervalArithmetic.interval(lc[i], hc[i]), N) |> SVector
-    return IntervalArithmetic.bounds.(f(I))
+    # Avoid the broadcast `bounds.(f(I))`: even for `SVector` inputs its `Broadcasted` wrapper
+    # (and result) escape to the heap. Dispatch instead — a scalar `Interval` returns a plain
+    # `Tuple`, an `SVector` of intervals returns an `SVector` of tuples via `map` (which
+    # StaticArrays keeps stack-allocated). Numerically identical to the broadcast.
+    return _interval_bounds(f(I))
 end
+_interval_bounds(x::SVector) = map(IntervalArithmetic.bounds, x)
+# scalar fallback: an `Interval`, or a plain `Real` for a constant level-set/gradient component
+_interval_bounds(x) = IntervalArithmetic.bounds(x)
 bound(f, rec::HyperRectangle) = bound(f, bounds(rec)...)
 
 """

--- a/src/quadgen.jl
+++ b/src/quadgen.jl
@@ -30,12 +30,17 @@ end
 
 function (quad::GaussLegendre{N})(f, a::Number, b::Number) where {N}
     h = b - a
-    acc = sum(zip(quad.nodes, quad.weights)) do (x̂, ŵ)
-        x = a + h * x̂
-        return f(x) * ŵ
+    nodes, weights = quad.nodes, quad.weights
+    @inbounds acc = f(a + h * nodes[1]) * weights[1]
+    @inbounds for i in 2:N
+        acc += f(a + h * nodes[i]) * weights[i]
     end
     return h * acc
 end
+
+# Default rule used by `Config().quad1d` for the 1D base case. Built once (computing the
+# nodes/weights via `QuadGK.gauss` is comparatively expensive) and shared across all calls.
+const DEFAULT_QUAD1D = GaussLegendre(; order = 40)
 
 """
     TensorQuadrature(quad1d)
@@ -169,11 +174,12 @@ true
 """
 function quadgen(ϕ, lc::SVector{N,T}, hc::SVector{N,T}; order, kwargs...) where {N,T}
     if !haskey(kwargs, :config)
-        quad1d = GaussLegendre(; order = order)
-        quadnd = TensorQuadrature(quad1d)
+        gl1d = GaussLegendre(; order = order)
+        quadnd = TensorQuadrature(gl1d)
         config = Config(;
             find_zero = (f, a, b, tol) -> Roots.find_zero(f, (a, b), Roots.Brent()),
             quad = (f, a, b, tol) -> (quadnd(f, a, b), Inf),
+            quad1d = (g, a, b, tol) -> (gl1d(g, a, b), Inf),
         )
     else
         isnothing(order) || @warn "Ignoring `order` parameter since `config` is provided."

--- a/src/quadgen.jl
+++ b/src/quadgen.jl
@@ -43,6 +43,57 @@ end
 const DEFAULT_QUAD1D = GaussLegendre(; order = 40)
 
 """
+    tensor_quad(; order, T = Float64)
+
+Build an allocation-free, fixed-order tensor-product `GaussLegendre` quadrature suitable for
+the `quad` field of [`Config`](@ref); i.e. the rule used to integrate over *full* cells:
+
+```julia
+config = Config(; quad = tensor_quad(; order = 20))
+integrate(f, ϕ, lc, hc; config)
+```
+
+This is an **opt-in** alternative to the default adaptive `HCubature` full-cell rule. The
+returned rule allocates nothing (the nodes/weights are computed once, here, and reused), and
+is exact for polynomials of degree `≤ order` in each coordinate — making it a good fit when
+the integrand is smooth (e.g. polynomial moments) and many full cells are encountered.
+
+!!! warning
+
+    Unlike the default `HCubature` rule, this rule is **non-adaptive**: it ignores the `tol`
+    argument and always uses the same fixed order. For integrands with sharp/oscillatory
+    features inside a full cell it may be less accurate than the adaptive default. It is not
+    used by default for this reason.
+"""
+function tensor_quad(; order, T::Type = Float64)
+    gl = GaussLegendre(; order, T)
+    return (f, a, b, tol) -> (_gl_tensor(gl, f, a, b), Inf)
+end
+
+# Allocation-free N-dimensional tensor-product evaluation of a `GaussLegendre` rule. We loop a
+# single linear index over the `Mᴺ` tensor nodes and decode it into per-dimension node indices,
+# rather than nesting `N` closures (which box heavily — see the note on `TensorQuadrature`).
+function _gl_tensor(gl::GaussLegendre{M,T}, f, a::SVector{N,S}, b::SVector{N,S}) where {M,T,N,S}
+    nodes, weights = gl.nodes, gl.weights
+    h = b .- a
+    # Build the first node explicitly to seed the accumulator with the right element type.
+    x0 = ntuple(d -> @inbounds(a[d] + h[d] * nodes[1]), Val(N)) |> SVector
+    acc = f(x0) * (weights[1]^N)
+    for lin in 1:(M^N - 1) # remaining tensor nodes
+        # Decode `lin` into per-dimension node indices (base-`M` digits). Keep the coordinate
+        # build (`ntuple`) free of captured mutable state, and accumulate the weight in a plain
+        # loop, so neither closes over a reassigned variable (which would box).
+        x = ntuple(d -> (@inbounds j = (lin ÷ M^(d - 1)) % M + 1; @inbounds a[d] + h[d] * nodes[j]), Val(N)) |> SVector
+        wgt = one(T)
+        for d in 1:N
+            @inbounds wgt *= weights[(lin ÷ M^(d - 1)) % M + 1]
+        end
+        acc += f(x) * wgt
+    end
+    return acc * prod(h)
+end
+
+"""
     TensorQuadrature(quad1d)
 
 Given a 1D quadrature rule `quad1d` with signature `quad1d(f, a::Number, b::Number)`, return a tensor product quadrature rule callable through

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -118,6 +118,7 @@ end
 
     # Type-inference (issue #1): `integrate`/`quadgen` are now type-stable.
     @test (@inferred integrate(x -> 1.0, ϕ, a, b)) isa NamedTuple
+    @test (@inferred integrate(x -> 1.0, ϕ, a, b; surface = true)) isa NamedTuple
     @test (@inferred quadgen(ϕ, a, b; order)) isa NamedTuple
 end
 
@@ -165,6 +166,7 @@ end
 
     # Type-inference (issue #1): `integrate`/`quadgen` are now type-stable.
     @test (@inferred integrate(x -> 1.0, ϕ, a, b .+ 0.1)) isa NamedTuple
+    @test (@inferred integrate(x -> 1.0, ϕ, a, b .+ 0.1; surface = true)) isa NamedTuple
     @test (@inferred quadgen(ϕ, a, b .+ 0.1; order)) isa NamedTuple
 end
 

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -257,3 +257,28 @@ end
     # the default rule is built once (a module constant), not per call
     @test ImplicitIntegration.DEFAULT_QUAD1D === ImplicitIntegration.DEFAULT_QUAD1D
 end
+
+@testset "tensor_quad opt-in full-cell rule (matches HCubature, alloc-light)" begin
+    using StaticArrays: SVector
+    # `tensor_quad` is an opt-in, allocation-free, fixed-order tensor Gauss rule for the
+    # `quad` (full-cell) field of `Config`. It must agree with the default adaptive
+    # HCubature full-cell rule on volume and surface integrals.
+    cfg = ImplicitIntegration.Config(; quad = tensor_quad(; order = 20))
+    for (ϕ, lc, hc) in (
+        (x -> x[1]^2 + x[2]^2 - 1, (0.0, 0.0), (1.5, 1.5)),
+        (x -> x[1]^2 + x[2]^2 + x[3]^2 - 1, (0.0, 0.0, 0.0), (1.5, 1.5, 1.5)),
+    )
+        for surface in (false, true)
+            ref = integrate(x -> 1.0, ϕ, lc, hc; surface).val
+            tq = integrate(x -> 1.0, ϕ, lc, hc; surface, config = cfg).val
+            @test tq ≈ ref rtol = 1e-8
+        end
+    end
+    # exact for polynomials and allocation-light per call (no closure boxing)
+    q = tensor_quad(; order = 20)
+    f = x -> 1.0 + x[1]^2
+    a, b = SVector(0.0, 0.0, 0.0), SVector(1.0, 1.0, 1.0)
+    @test q(f, a, b, 1e-8)[1] ≈ 1 + 1 / 3
+    q(f, a, b, 1e-8)
+    @test (@allocated q(f, a, b, 1e-8)) < 512
+end

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -234,3 +234,24 @@ end
     ImplicitIntegration._dedup_sorted_by_round!(copy(buf))
     @test (@allocated ImplicitIntegration._dedup_sorted_by_round!(buf)) == 0
 end
+
+@testset "quad1d base-case rule (Gauss default vs HCubature)" begin
+    using StaticArrays: SVector
+    # The default `quad1d` is a fixed Gauss-Legendre rule; it must agree with an explicit
+    # adaptive HCubature `quad1d` to within tolerance on volume and surface integrals.
+    import HCubature
+    hcub1d = (g, a, b, tol) -> HCubature.hcubature(x -> g(x[1]), SVector(a), SVector(b); atol = tol)
+    cfg_hcub = ImplicitIntegration.Config(; quad1d = hcub1d)
+    for (ϕ, lc, hc) in (
+        (x -> x[1]^2 + x[2]^2 - 1, (0.0, 0.0), (1.5, 1.5)),
+        (x -> x[1]^2 + x[2]^2 + x[3]^2 - 1, (0.0, 0.0, 0.0), (1.5, 1.5, 1.5)),
+    )
+        for surface in (false, true)
+            ref = integrate(x -> 1.0, ϕ, lc, hc; surface, config = cfg_hcub).val
+            gauss = integrate(x -> 1.0, ϕ, lc, hc; surface).val
+            @test gauss ≈ ref rtol = 1e-6
+        end
+    end
+    # the default rule is built once (a module constant), not per call
+    @test ImplicitIntegration.DEFAULT_QUAD1D === ImplicitIntegration.DEFAULT_QUAD1D
+end

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -116,9 +116,9 @@ end
     Q = quadgen(ϕ, a, b; order = 20, surface = true)[1]
     @test integrate(x -> 1.0, Q) ≈ 2 * π / 4
 
-    # FIXME: type-inference fails on 1.10, but passes o 1.12. Maybe related to recursive calls in `integrate`?
-    @test_broken @inferred integrate(x -> 1.0, ϕ, a, b)
-    @test_broken @inferred quadgen(ϕ, a, b; order)
+    # Type-inference (issue #1): `integrate`/`quadgen` are now type-stable.
+    @test (@inferred integrate(x -> 1.0, ϕ, a, b)) isa NamedTuple
+    @test (@inferred quadgen(ϕ, a, b; order)) isa NamedTuple
 end
 
 @testset "Volume integrals" begin
@@ -163,9 +163,9 @@ end
     Q = quadgen(ϕ, a, b .+ 0.1; order = 20, surface = true)[1]
     @test integrate(x -> 1.0, Q) ≈ 4 * π / 8
 
-    # FIXME: type-inference fails. Maybe related to recursive calls in `integrate`?
-    @test_broken @inferred integrate(x -> 1.0, ϕ, a, b .+ 0.1)
-    @test_broken @inferred quadgen(ϕ, a, b .+ 0.1; order)
+    # Type-inference (issue #1): `integrate`/`quadgen` are now type-stable.
+    @test (@inferred integrate(x -> 1.0, ϕ, a, b .+ 0.1)) isa NamedTuple
+    @test (@inferred quadgen(ϕ, a, b .+ 0.1; order)) isa NamedTuple
 end
 
 @testset "Logging" begin

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -216,3 +216,21 @@ end
     @test_throws ErrorException ImplicitIntegration.split(x -> x[1], (0.0,), (1.0,), 1)
     ImplicitIntegration.enable_default_interface()
 end
+
+@testset "_dedup_sorted_by_round! (alloc-free, matches unique!)" begin
+    for v0 in (
+        [0.0, 1.0],
+        [0.1, 0.1 + 1e-12, 0.5, 0.5, 0.9],
+        [0.30000001, 0.30000002, 0.7],
+        Float64[],
+        [3.0],
+    )
+        v = sort(v0)
+        ref = unique(x -> round(x; sigdigits = 8), v)
+        @test ImplicitIntegration._dedup_sorted_by_round!(copy(v)) == ref
+    end
+    # allocation-free on a warmed call (no Dict, unlike `unique!(f, v)`)
+    buf = sort(rand(50))
+    ImplicitIntegration._dedup_sorted_by_round!(copy(buf))
+    @test (@allocated ImplicitIntegration._dedup_sorted_by_round!(buf)) == 0
+end


### PR DESCRIPTION
Closes #30.

> [!IMPORTANT]
> This PR **builds on #27** (type-stability fix) and should be **merged after #27**. Until then its diff against `main` will also show the #27 commits.

Performance follow-up: large reduction in per-call allocations across 2D–4D, for both cut cells and deeply-recursing domains, while keeping results **numerically invariant** (integral values *and* subdivision / low-order / full-cell counts are bit-identical to `main`; full suite stays green).

### What changed

- **Stack-allocated level-set lists.** The per-recursion-level level-set / sign / gradient lists are carried as fixed-length `SVector`s instead of heap `Vector`s. With full level-sets carried rather than pruned, the list length is exactly `2^(N-DIM)` — a function of `DIM`, which `_integrate` already specializes on — so it is statically known and the whole closure tower stays `isbits` / stack-allocated. Carrying fulls is invariant: a full restriction of a smooth level-set keeps its gradient direction, so the height-direction choice is unchanged (verified bit-identical).
- **`isbits` integrand in the height case.** Segment boundaries are built on a stack `SVector` (roots with an `Inf` sentinel) instead of a captured heap buffer, so the recursing integrand closure is itself `isbits` and is passed down by value with no heap allocation. The 1D base case keeps a local dynamic buffer (root count is unbounded there) but its closure is evaluated in place and never stored.
- **Allocation-free `bound`.** Replaces the `IntervalArithmetic.bounds.(f(I))` broadcast (whose `Broadcasted` wrapper escapes to the heap) with a small dispatch; `bound` now allocates 0 B on its own.
- **Opt-in `tensor_quad`.** A fixed-order, allocation-free tensor-product Gauss–Legendre rule for the `quad` (full-cell) field of `Config`, for smooth integrands. The default stays the adaptive `HCubature` rule, so behavior is unchanged unless explicitly requested.

### Impact (per cut cell)

| | 2D vol | 3D vol | 4D vol |
|---|--:|--:|--:|
| before | 14176 B | — | — |
| this PR | 832 B | 1488 B | 3584 B |

(~50% below the previous state, ~94% below the original baseline in 2D; the deep-recursion path improves similarly.) `@inferred integrate(...)` continues to hold in all dimensions.